### PR TITLE
Add missing link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ### WarsawJS Workshop #22: Testowanie kodu 1/3: Testy jednostkowe
 
+* <https://warsawjs.github.io/workshop-setup/22/4/>
 * <https://warsawjs.github.io/workshop-setup/22/5/>
 
 ### WarsawJS Workshop #23: Testowanie kodu 2/3: Testy end-to-end


### PR DESCRIPTION
## Overview

This PR adds missing link to `README.md`, pointing to the setup instructions for workshop #22 (group 4).